### PR TITLE
fix: stop terraform workflow from concurrent execution

### DIFF
--- a/.github/workflows/terraform-deploy.yaml
+++ b/.github/workflows/terraform-deploy.yaml
@@ -10,6 +10,7 @@ on:
 defaults:
   run:
     shell: bash
+concurrency: ${{ github.head_ref || github.ref_name || github.run_id }}
 jobs:
   terraform:
     name:   ${{matrix.runner}} - dev


### PR DESCRIPTION
Will stop future merges from concurrently running terraform
