### PR TITLE
delete ecr repo even if not empty

### DIFF
--- a/infracode/bootstrap/main.tf
+++ b/infracode/bootstrap/main.tf
@@ -1,7 +1,9 @@
 data "aws_caller_identity" "current" {}
 
 resource "aws_ecr_repository" "acme-tech-challenge-ecr" {
-  name = "${var.team}-${var.project}-app"
+  name         = "${var.team}-${var.project}-app"
+  force_delete = true
+
   image_scanning_configuration {
     scan_on_push = true
   }


### PR DESCRIPTION
Need to be able to delete the repo even if it still has images. Tested this by running the destroy bootstrap script in a new AWS account at the end of testing the whole stack.